### PR TITLE
Feature/235 commons project

### DIFF
--- a/src/main/java/ch/hsr/array/ADVElementsShowcase.java
+++ b/src/main/java/ch/hsr/array/ADVElementsShowcase.java
@@ -1,8 +1,8 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;

--- a/src/main/java/ch/hsr/array/ADVElementsShowcase.java
+++ b/src/main/java/ch/hsr/array/ADVElementsShowcase.java
@@ -1,13 +1,13 @@
 package ch.hsr.array;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVWarningStyle;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 
 public class ADVElementsShowcase {

--- a/src/main/java/ch/hsr/array/BubbleSort.java
+++ b/src/main/java/ch/hsr/array/BubbleSort.java
@@ -1,10 +1,10 @@
 package ch.hsr.array;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 
 public class BubbleSort {

--- a/src/main/java/ch/hsr/array/BubbleSort.java
+++ b/src/main/java/ch/hsr/array/BubbleSort.java
@@ -1,8 +1,8 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.util.ADVException;
 

--- a/src/main/java/ch/hsr/array/LinearSearch.java
+++ b/src/main/java/ch/hsr/array/LinearSearch.java
@@ -1,8 +1,8 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;

--- a/src/main/java/ch/hsr/array/LinearSearch.java
+++ b/src/main/java/ch/hsr/array/LinearSearch.java
@@ -1,12 +1,12 @@
 package ch.hsr.array;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 
 public class LinearSearch {

--- a/src/main/java/ch/hsr/array/ObjectArray.java
+++ b/src/main/java/ch/hsr/array/ObjectArray.java
@@ -1,8 +1,8 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 
 public class ObjectArray {

--- a/src/main/java/ch/hsr/array/PrimitiveArray.java
+++ b/src/main/java/ch/hsr/array/PrimitiveArray.java
@@ -1,8 +1,8 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 
 public class PrimitiveArray {

--- a/src/main/java/ch/hsr/array/StylesShowcase.java
+++ b/src/main/java/ch/hsr/array/StylesShowcase.java
@@ -1,9 +1,14 @@
 package ch.hsr.array;
 
+import ch.hsr.adv.commons.core.logic.domain.styles.*;
+import ch.hsr.adv.commons.core.logic.domain.styles.presets.ADVDefaultStyle;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.domain.styles.*;
-import ch.hsr.adv.lib.core.logic.domain.styles.presets.*;
+import ch.hsr.adv.lib.core.logic.domain.styles.ADVEnumStyle;
+import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
+import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
+import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
+import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVWarningStyle;
 import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 public class StylesShowcase {
@@ -38,7 +43,7 @@ public class StylesShowcase {
 
         // -------- snapshot 3 -------- //
         setStyle(8, new ADVValueStyle(0xff66ff, ADVStrokeStyle.DASHED, 4));
-        setStyle(9, new ADVValueStyle(0xcc9900, ADVStrokeStyle.DOTTED, 2, 0xffffcc));
+        setStyle(9, new ADVValueStyle(0xffffcc, 0xcc9900, ADVStrokeStyle.DOTTED, 2));
         ADV.snapshot(arrayModule, "Using value style.");
     }
 

--- a/src/main/java/ch/hsr/array/StylesShowcase.java
+++ b/src/main/java/ch/hsr/array/StylesShowcase.java
@@ -2,6 +2,7 @@ package ch.hsr.array;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.*;
 import ch.hsr.adv.commons.core.logic.domain.styles.presets.ADVDefaultStyle;
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.array.logic.ArrayModule;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.ADVEnumStyle;
@@ -9,7 +10,6 @@ import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVInfoStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVWarningStyle;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 
 public class StylesShowcase {
     // instantiate data structure container

--- a/src/main/java/ch/hsr/graph/DepthFirstSearch.java
+++ b/src/main/java/ch/hsr/graph/DepthFirstSearch.java
@@ -7,7 +7,6 @@ import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.graph.logic.GraphModule;
 import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
 import ch.hsr.adv.lib.stack.logic.StackModule;
-import ch.hsr.adv.lib.stack.logic.domain.EmptyStackException;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;
 import ch.hsr.graph.model.Vertex;

--- a/src/main/java/ch/hsr/graph/DepthFirstSearch.java
+++ b/src/main/java/ch/hsr/graph/DepthFirstSearch.java
@@ -1,11 +1,11 @@
 package ch.hsr.graph;
 
 import ch.hsr.adv.commons.core.logic.util.ADVException;
+import ch.hsr.adv.commons.graph.logic.domain.ADVVertex;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
-import ch.hsr.adv.lib.graph.logic.GraphModule;
-import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
+import ch.hsr.adv.lib.graph.logic.domain.GraphModule;
 import ch.hsr.adv.lib.stack.logic.StackModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;

--- a/src/main/java/ch/hsr/graph/DepthFirstSearch.java
+++ b/src/main/java/ch/hsr/graph/DepthFirstSearch.java
@@ -1,9 +1,9 @@
 package ch.hsr.graph;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVErrorStyle;
 import ch.hsr.adv.lib.core.logic.domain.styles.presets.ADVSuccessStyle;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.graph.logic.GraphModule;
 import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
 import ch.hsr.adv.lib.stack.logic.StackModule;

--- a/src/main/java/ch/hsr/graph/MultipleEdgesGraph.java
+++ b/src/main/java/ch/hsr/graph/MultipleEdgesGraph.java
@@ -1,7 +1,7 @@
 package ch.hsr.graph;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.graph.logic.GraphModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;

--- a/src/main/java/ch/hsr/graph/MultipleEdgesGraph.java
+++ b/src/main/java/ch/hsr/graph/MultipleEdgesGraph.java
@@ -2,7 +2,7 @@ package ch.hsr.graph;
 
 import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.graph.logic.GraphModule;
+import ch.hsr.adv.lib.graph.logic.domain.GraphModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;
 import ch.hsr.graph.model.Vertex;

--- a/src/main/java/ch/hsr/graph/NormalGraph.java
+++ b/src/main/java/ch/hsr/graph/NormalGraph.java
@@ -1,7 +1,7 @@
 package ch.hsr.graph;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.graph.logic.GraphModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;

--- a/src/main/java/ch/hsr/graph/NormalGraph.java
+++ b/src/main/java/ch/hsr/graph/NormalGraph.java
@@ -1,8 +1,9 @@
 package ch.hsr.graph;
 
+
 import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.graph.logic.GraphModule;
+import ch.hsr.adv.lib.graph.logic.domain.GraphModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;
 import ch.hsr.graph.model.Vertex;

--- a/src/main/java/ch/hsr/graph/model/Edge.java
+++ b/src/main/java/ch/hsr/graph/model/Edge.java
@@ -1,7 +1,7 @@
 package ch.hsr.graph.model;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
-import ch.hsr.adv.lib.graph.logic.domain.ADVEdge;
+import ch.hsr.adv.commons.graph.logic.domain.ADVEdge;
 
 public class Edge<E> implements ADVEdge<E> {
 

--- a/src/main/java/ch/hsr/graph/model/Edge.java
+++ b/src/main/java/ch/hsr/graph/model/Edge.java
@@ -1,6 +1,6 @@
 package ch.hsr.graph.model;
 
-import ch.hsr.adv.lib.core.logic.domain.styles.ADVStyle;
+import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.graph.logic.domain.ADVEdge;
 
 public class Edge<E> implements ADVEdge<E> {

--- a/src/main/java/ch/hsr/graph/model/Edge.java
+++ b/src/main/java/ch/hsr/graph/model/Edge.java
@@ -18,7 +18,7 @@ public class Edge<E> implements ADVEdge<E> {
     public Edge(Vertex sourceVertex, Vertex targetVertex, boolean directed) {
         this(sourceVertex.getId(), targetVertex.getId(), directed);
     }
-    
+
     public Edge(long sourceVertexId, long targetVertexId) {
         this(sourceVertexId, targetVertexId, false);
     }
@@ -40,8 +40,18 @@ public class Edge<E> implements ADVEdge<E> {
     }
 
     @Override
+    public void setSourceElementId(long sourceVertexId) {
+        this.sourceVertexId = sourceVertexId;
+    }
+
+    @Override
     public long getTargetElementId() {
         return targetVertexId;
+    }
+
+    @Override
+    public void setTargetElementId(long targetVertexId) {
+        this.targetVertexId = targetVertexId;
     }
 
     @Override

--- a/src/main/java/ch/hsr/graph/model/Graph.java
+++ b/src/main/java/ch/hsr/graph/model/Graph.java
@@ -1,7 +1,7 @@
 package ch.hsr.graph.model;
 
-import ch.hsr.adv.lib.graph.logic.domain.ADVGraph;
-import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
+import ch.hsr.adv.commons.graph.logic.domain.ADVGraph;
+import ch.hsr.adv.commons.graph.logic.domain.ADVVertex;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/ch/hsr/graph/model/Vertex.java
+++ b/src/main/java/ch/hsr/graph/model/Vertex.java
@@ -1,8 +1,8 @@
 package ch.hsr.graph.model;
 
 import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
-import ch.hsr.adv.lib.graph.logic.domain.ADVGraph;
-import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
+import ch.hsr.adv.commons.graph.logic.domain.ADVGraph;
+import ch.hsr.adv.commons.graph.logic.domain.ADVVertex;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/ch/hsr/graph/model/Vertex.java
+++ b/src/main/java/ch/hsr/graph/model/Vertex.java
@@ -1,6 +1,6 @@
 package ch.hsr.graph.model;
 
-import ch.hsr.adv.lib.core.logic.domain.styles.ADVStyle;
+import ch.hsr.adv.commons.core.logic.domain.styles.ADVStyle;
 import ch.hsr.adv.lib.graph.logic.domain.ADVGraph;
 import ch.hsr.adv.lib.graph.logic.domain.ADVVertex;
 

--- a/src/main/java/ch/hsr/multi/MultiModule.java
+++ b/src/main/java/ch/hsr/multi/MultiModule.java
@@ -1,7 +1,9 @@
 package ch.hsr.multi;
 
+
+
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.graph.logic.GraphModule;
 import ch.hsr.adv.lib.stack.logic.StackModule;
 import ch.hsr.graph.model.Edge;

--- a/src/main/java/ch/hsr/multi/MultiModule.java
+++ b/src/main/java/ch/hsr/multi/MultiModule.java
@@ -4,7 +4,7 @@ package ch.hsr.multi;
 
 import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
-import ch.hsr.adv.lib.graph.logic.GraphModule;
+import ch.hsr.adv.lib.graph.logic.domain.GraphModule;
 import ch.hsr.adv.lib.stack.logic.StackModule;
 import ch.hsr.graph.model.Edge;
 import ch.hsr.graph.model.Graph;

--- a/src/main/java/ch/hsr/stack/CustomContentStackShowcase.java
+++ b/src/main/java/ch/hsr/stack/CustomContentStackShowcase.java
@@ -1,8 +1,8 @@
 package ch.hsr.stack;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.ADVModule;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.stack.logic.StackModule;
 import ch.hsr.adv.lib.stack.logic.domain.ADVStack;
 import ch.hsr.stack.model.Stack;

--- a/src/main/java/ch/hsr/stack/StackShowcase.java
+++ b/src/main/java/ch/hsr/stack/StackShowcase.java
@@ -1,8 +1,8 @@
 package ch.hsr.stack;
 
+import ch.hsr.adv.commons.core.logic.util.ADVException;
 import ch.hsr.adv.lib.bootstrapper.ADV;
 import ch.hsr.adv.lib.core.logic.ADVModule;
-import ch.hsr.adv.lib.core.logic.util.ADVException;
 import ch.hsr.adv.lib.stack.logic.StackModule;
 import ch.hsr.adv.lib.stack.logic.domain.ADVStack;
 import ch.hsr.stack.model.Stack;

--- a/src/main/java/ch/hsr/stack/model/Stack.java
+++ b/src/main/java/ch/hsr/stack/model/Stack.java
@@ -1,7 +1,7 @@
 package ch.hsr.stack.model;
 
 import ch.hsr.adv.lib.stack.logic.domain.ADVStack;
-import ch.hsr.adv.lib.stack.logic.domain.EmptyStackException;
+import ch.hsr.adv.lib.stack.logic.exceptions.EmptyStackException;
 
 public class Stack<T> implements ADVStack<T> {
 


### PR DESCRIPTION
Domain Objekte des Core und aller drei Module im Commons Project vereint (Ausnahme Session Klasse)

Grund Session: Auf Lib Seite gibt es pro Session nur ein Snapshot, der jeweils überschrieben wird. (Ich habe deshalb vorerst auf einen Merge verzichtet) -> In einer Stashed Version wurde der Merge probehalber durchgeführt.
 
Mit den DefaultSerializer, und CoreStringifyer habe ich ebenfalls bewusst gewartet, da diese viele Abhängigkeiten zu ServiceProvider und ModuleGroupSerializer, etc. haben. Ich würde diesen Merge in einem neuen Issue durchführen und entsprechende Klassen mit einem Interface abstrahieren. (Am besten wir besprechen das morgen zusammen)

Für das Fixen des Travis Build habe ich einen eigenständiges Issue erstellt: #ADV-273